### PR TITLE
rfbridge: centralise MQTT topic sanitisation (issue #10, option B)

### DIFF
--- a/433rfbridge_proxy.py
+++ b/433rfbridge_proxy.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
-"""433 MHz RF Bridge MQTT Proxy — Portisch/Tasmota AA B1 Frame Decoder.
+"""433 MHz RF Bridge MQTT Proxy — entry point.
 
-Subscribes to the internal broker for raw RF data from a Sonoff RF Bridge
-running Tasmota + Portisch firmware, decodes PDM bucket frames, maps sensor
-IDs to friendly names, and republishes structured JSON to the central broker.
+This script is the entry point loaded by deploy/433rfbridge-proxy.service.
+It loads config.yaml and sensors.yaml, instantiates RfBridgeMqttBridge,
+handles SIGTERM/SIGINT, and runs the periodic maintenance loop.
+
+All business logic lives in src/rfbridge/:
+  bridge.py          — RfBridgeConfig, RfBridgeMqttBridge (two-broker MQTT bridge)
+  ha_discovery.py    — Home Assistant MQTT autodiscovery payloads and publishing
+  protocol.py        — AA B1 frame parser (Portisch/Tasmota Nexus-compatible sensors)
+  sensor_registry.py — Persistent sensor name↔ID mapping, deduplication, dead-sensor tracking
+  utils.py           — Shared helpers (sanitise_topic_name)
 """
 
 import logging

--- a/src/rfbridge/bridge.py
+++ b/src/rfbridge/bridge.py
@@ -22,6 +22,7 @@ import paho.mqtt.client as mqtt
 from src.rfbridge.ha_discovery import clear_discovery, publish_discovery
 from src.rfbridge.protocol import DecodedFrame, parse_rfraw_payload
 from src.rfbridge.sensor_registry import DeadSensorRegistry, Deduplicator, SensorRegistry
+from src.rfbridge.utils import sanitise_topic_name
 
 logger = logging.getLogger(__name__)
 
@@ -208,7 +209,7 @@ class RfBridgeMqttBridge:
         self._publish_state(friendly_name, frame)
 
     def _publish_state(self, friendly_name: str, frame: DecodedFrame) -> None:
-        topic = f"{self.config.output_topic_prefix}/{friendly_name}/state"
+        topic = f"{self.config.output_topic_prefix}/{sanitise_topic_name(friendly_name)}/state"
         payload = json.dumps({
             "temperature": frame.temperature,
             "humidity": frame.humidity,

--- a/src/rfbridge/ha_discovery.py
+++ b/src/rfbridge/ha_discovery.py
@@ -20,6 +20,8 @@ import logging
 
 import paho.mqtt.client as mqtt
 
+from src.rfbridge.utils import sanitise_topic_name
+
 logger = logging.getLogger(__name__)
 
 DISCOVERY_PREFIX = "homeassistant"
@@ -42,7 +44,7 @@ def _device_block(friendly_name: str, protocol: str, channel: int) -> dict:
 
 
 def _state_topic(output_topic_prefix: str, friendly_name: str) -> str:
-    return f"{output_topic_prefix}/{friendly_name}/state"
+    return f"{output_topic_prefix}/{sanitise_topic_name(friendly_name)}/state"
 
 
 def make_temperature_discovery_payload(
@@ -95,15 +97,17 @@ def make_battery_low_discovery_payload(
 
 def discovery_topic(friendly_name: str, sensor_type: str) -> str:
     component = "binary_sensor" if sensor_type == "battery_low" else "sensor"
-    return f"{DISCOVERY_PREFIX}/{component}/433rfbridge_{friendly_name}_{sensor_type}/config"
+    safe = sanitise_topic_name(friendly_name)
+    return f"{DISCOVERY_PREFIX}/{component}/433rfbridge_{safe}_{sensor_type}/config"
 
 
 def clear_discovery(client: mqtt.Client, friendly_name: str) -> None:
     """Remove all retained discovery entries for a sensor (e.g. after rename/removal)."""
+    safe = sanitise_topic_name(friendly_name)
     for sensor_type in ("temperature", "humidity"):
-        topic = f"{DISCOVERY_PREFIX}/sensor/433rfbridge_{friendly_name}_{sensor_type}/config"
+        topic = f"{DISCOVERY_PREFIX}/sensor/433rfbridge_{safe}_{sensor_type}/config"
         client.publish(topic, b"", qos=1, retain=True)
-    topic = f"{DISCOVERY_PREFIX}/binary_sensor/433rfbridge_{friendly_name}_battery_low/config"
+    topic = f"{DISCOVERY_PREFIX}/binary_sensor/433rfbridge_{safe}_battery_low/config"
     client.publish(topic, b"", qos=1, retain=True)
     logger.info("Cleared HA discovery entries for removed/renamed sensor '%s'", friendly_name)
 
@@ -121,7 +125,7 @@ def publish_discovery(
     Any stale sensor-component entry for battery_low is cleared on each publish.
     """
     # Clear stale sensor-component entry for battery_low (published before binary_sensor fix)
-    stale_topic = f"{DISCOVERY_PREFIX}/sensor/433rfbridge_{friendly_name}_battery_low/config"
+    stale_topic = f"{DISCOVERY_PREFIX}/sensor/433rfbridge_{sanitise_topic_name(friendly_name)}_battery_low/config"
     client.publish(stale_topic, b"", qos=1, retain=True)
 
     entities = [

--- a/src/rfbridge/utils.py
+++ b/src/rfbridge/utils.py
@@ -1,0 +1,22 @@
+"""Shared utilities for the RF bridge proxy."""
+
+import re
+
+_UMLAUT_MAP = str.maketrans({
+    'ä': 'ae', 'ö': 'oe', 'ü': 'ue',
+    'Ä': 'Ae', 'Ö': 'Oe', 'Ü': 'Ue',
+    'ß': 'ss',
+})
+
+
+def sanitise_topic_name(name: str) -> str:
+    """Convert a friendly sensor name to a safe MQTT topic segment.
+
+    Replaces German umlauts with ASCII equivalents, then replaces any
+    remaining non-alphanumeric characters (except hyphen) with underscores,
+    and collapses consecutive underscores.
+    """
+    name = name.translate(_UMLAUT_MAP)
+    name = re.sub(r'[^A-Za-z0-9_-]', '_', name)
+    name = re.sub(r'_+', '_', name)
+    return name.strip('_')

--- a/tests/unit/rfbridge/test_bridge.py
+++ b/tests/unit/rfbridge/test_bridge.py
@@ -8,6 +8,7 @@ import paho.mqtt.client as mqtt
 import pytest
 
 from src.rfbridge.bridge import RfBridgeConfig, RfBridgeMqttBridge
+from src.rfbridge.protocol import DecodedFrame
 
 
 MINIMAL_CFG = {
@@ -112,3 +113,43 @@ class TestTasmotaDiscoveryForwarding:
         bridge._forward_tasmota_discovery(msg)  # should not raise
         # Message still cached even on publish failure
         assert "tasmota/discovery/AABBCC/config" in bridge._tasmota_discovery_cache
+
+
+def _make_frame() -> DecodedFrame:
+    return DecodedFrame(
+        protocol="nexus_compatible",
+        sof=0,
+        device_id=0xAB,
+        battery_ok=True,
+        tx_button=False,
+        channel=1,
+        temperature=21.0,
+        humidity=50,
+        raw_data="AA B1 ...",
+    )
+
+
+class TestPublishStateSanitisation:
+    def test_state_topic_sanitises_spaces(self, bridge):
+        frame = _make_frame()
+        bridge._publish_state("EG Wohnzimmer", frame)
+        topic = bridge._central.publish.call_args.args[0]
+        assert " " not in topic
+        assert topic == "tele/433rfbridge/EG_Wohnzimmer/state"
+
+    def test_state_topic_sanitises_umlauts(self, bridge):
+        frame = _make_frame()
+        bridge._publish_state("EG Wohnküche", frame)
+        topic = bridge._central.publish.call_args.args[0]
+        assert "ü" not in topic
+        assert topic == "tele/433rfbridge/EG_Wohnkueche/state"
+
+    def test_state_topic_matches_discovery_state_topic(self, bridge):
+        from src.rfbridge.ha_discovery import make_temperature_discovery_payload
+        raw_name = "EG Wohnküche"
+        frame = _make_frame()
+        bridge._publish_state(raw_name, frame)
+        published_topic = bridge._central.publish.call_args.args[0]
+        # Strip the /state suffix to get the prefix for comparison
+        discovery_payload = make_temperature_discovery_payload(raw_name, "nexus_compatible", 1, "tele/433rfbridge")
+        assert discovery_payload["state_topic"] == published_topic

--- a/tests/unit/rfbridge/test_ha_discovery.py
+++ b/tests/unit/rfbridge/test_ha_discovery.py
@@ -12,6 +12,7 @@ from src.rfbridge.ha_discovery import (
     make_temperature_discovery_payload,
     publish_discovery,
 )
+from src.rfbridge.utils import sanitise_topic_name
 
 OUTPUT_PREFIX = "tele/433rfbridge"
 SENSOR_NAME = "living_room"
@@ -100,3 +101,41 @@ class TestClearDiscovery:
         assert any("temperature" in t for t in topics)
         assert any("humidity" in t for t in topics)
         assert any("battery_low" in t for t in topics)
+
+
+class TestSanitisedTopicNames:
+    """Verify that spaces and umlauts in friendly names are normalised in all topic paths."""
+
+    RAW_NAME = "EG Wohnküche"
+    SAFE_NAME = "EG_Wohnkueche"
+
+    def test_state_topic_uses_sanitised_name(self):
+        payload = make_temperature_discovery_payload(self.RAW_NAME, PROTOCOL, CHANNEL, OUTPUT_PREFIX)
+        assert payload["state_topic"] == f"{OUTPUT_PREFIX}/{self.SAFE_NAME}/state"
+
+    def test_state_topic_no_raw_chars(self):
+        payload = make_temperature_discovery_payload(self.RAW_NAME, PROTOCOL, CHANNEL, OUTPUT_PREFIX)
+        assert " " not in payload["state_topic"]
+        assert "ü" not in payload["state_topic"]
+
+    def test_discovery_topic_uses_sanitised_name(self):
+        topic = discovery_topic(self.RAW_NAME, "temperature")
+        assert self.SAFE_NAME in topic
+        assert " " not in topic
+        assert "ü" not in topic
+
+    def test_clear_discovery_uses_sanitised_name(self):
+        client = MagicMock()
+        client.publish.return_value = MagicMock(rc=mqtt.MQTT_ERR_SUCCESS)
+        clear_discovery(client, self.RAW_NAME)
+        topics = [c.args[0] for c in client.publish.call_args_list]
+        for t in topics:
+            assert " " not in t, f"Space found in topic: {t}"
+            assert "ü" not in t, f"Umlaut found in topic: {t}"
+        assert any(self.SAFE_NAME in t for t in topics)
+
+    def test_state_topic_matches_between_discovery_and_bridge_publish(self):
+        # The topic bridge.py will publish to must match ha_discovery.py's state_topic.
+        payload = make_temperature_discovery_payload(self.RAW_NAME, PROTOCOL, CHANNEL, OUTPUT_PREFIX)
+        expected_state_topic = f"{OUTPUT_PREFIX}/{sanitise_topic_name(self.RAW_NAME)}/state"
+        assert payload["state_topic"] == expected_state_topic

--- a/tests/unit/rfbridge/test_utils.py
+++ b/tests/unit/rfbridge/test_utils.py
@@ -1,0 +1,54 @@
+"""Unit tests for src/rfbridge/utils.py."""
+
+import pytest
+
+from src.rfbridge.utils import sanitise_topic_name
+
+
+class TestSanitiseTopicName:
+    def test_clean_name_unchanged(self):
+        assert sanitise_topic_name("living_room") == "living_room"
+
+    def test_space_replaced_by_underscore(self):
+        assert sanitise_topic_name("EG Wohnkueche") == "EG_Wohnkueche"
+
+    def test_umlaut_ue(self):
+        assert sanitise_topic_name("Wohnküche") == "Wohnkueche"
+
+    def test_umlaut_ae(self):
+        assert sanitise_topic_name("Schlafzimmer Käthe") == "Schlafzimmer_Kaethe"
+
+    def test_umlaut_oe(self):
+        assert sanitise_topic_name("Flur Öst") == "Flur_Oest"
+
+    def test_umlaut_ue_uppercase(self):
+        assert sanitise_topic_name("Übergabe") == "Uebergabe"
+
+    def test_umlaut_ae_uppercase(self):
+        assert sanitise_topic_name("Äpfel") == "Aepfel"
+
+    def test_umlaut_oe_uppercase(self):
+        assert sanitise_topic_name("Öfen") == "Oefen"
+
+    def test_eszett(self):
+        assert sanitise_topic_name("Straße") == "Strasse"
+
+    def test_full_example_eg_wohnkueche(self):
+        assert sanitise_topic_name("EG Wohnküche") == "EG_Wohnkueche"
+
+    def test_full_example_eg_arbeitszimmer(self):
+        assert sanitise_topic_name("EG Arbeitszimmer") == "EG_Arbeitszimmer"
+
+    def test_multiple_spaces_collapse(self):
+        assert sanitise_topic_name("EG  Zimmer") == "EG_Zimmer"
+
+    def test_hyphen_preserved(self):
+        assert sanitise_topic_name("living-room") == "living-room"
+
+    def test_special_chars_replaced(self):
+        result = sanitise_topic_name("sensor/1")
+        assert "/" not in result
+        assert result == "sensor_1"
+
+    def test_leading_trailing_underscores_stripped(self):
+        assert sanitise_topic_name(" sensor ") == "sensor"


### PR DESCRIPTION
## Summary

- Extracted `sanitise_topic_name(name: str) -> str` into `src/rfbridge/utils.py`
- Applied it in `bridge.py` (`_publish_state`) and `ha_discovery.py` (`_state_topic`, `discovery_topic`, `clear_discovery`) so both derive every MQTT topic segment from the same function
- Documented the entry-point vs library relationship in `433rfbridge_proxy.py`
- Added `tests/unit/rfbridge/test_utils.py` (15 test cases covering umlauts, spaces, special chars) and extended `test_ha_discovery.py` / `test_bridge.py` with sanitisation assertions

Closes #10

## Root cause fixed

`ha_discovery.py` and `bridge.py` were each deriving the MQTT topic independently with inconsistent sanitisation rules, causing HA entities to point to `tele/433rfbridge/EG_Wohnkueche/state` while the proxy published live data to `tele/433rfbridge/EG Wohnküche/state`.

## Test plan
- [x] All 219 unit tests pass (`python -m pytest tests/unit/`)
- [x] `test_state_topic_matches_discovery_state_topic` explicitly asserts both sides produce the same topic for an unsanitised name
- [x] `test_full_example_eg_wohnkueche` / `test_full_example_eg_arbeitszimmer` cover the real-world sensor names from the bug report

🤖 Generated with [Claude Code](https://claude.com/claude-code)